### PR TITLE
Remove infinite spinner bug when no face is detected

### DIFF
--- a/frontend/app/(main)/post/new/new-post-photo.tsx
+++ b/frontend/app/(main)/post/new/new-post-photo.tsx
@@ -8,6 +8,7 @@ export type NewPostPhotoProps = TagDotProps_ & {
     imgProcessing: boolean,
     setImage: (_: Blob) => void,
     cachedImage: MutableRefObject<[Blob, boolean] | null>,
+    noFaceCallback: () => void
 };
 
 const genKey = (() => {
@@ -40,9 +41,7 @@ export default forwardRef(function NewPostPhoto(props: NewPostPhotoProps, ref: F
 
         if (props.blur) {
             if (cache.current === null || !cache.current[1]) {
-                detectFace(imgRef.current, props.setImage, () => {
-                    // Called if for loop doesn't run
-                });
+                detectFace(imgRef.current, props.setImage, props.noFaceCallback);
             } else {
                 props.setImage(cache.current[0]);
             }

--- a/frontend/app/(main)/post/new/page.tsx
+++ b/frontend/app/(main)/post/new/page.tsx
@@ -170,10 +170,9 @@ export default function Home() {
                         {...dotProps}
                         ref={imgRef}
                         blur={blur}
-                        setImage={b => {
-                            setImage(new File([b], image.name));
-                            setImgProcessing(false);
-                        }} />}
+                        setImage={b => setImage(new File([b], image.name))}
+                        noFaceCallback={() => setImgProcessing(false)}
+                    />}
                     {tagEditor}
                 </div>
                 <div className="settings">


### PR DESCRIPTION
Add callback to detectFace function
- callback will run when no faces are detected
- callback sets imgProcessing state to false so the spinner will stop being displayed